### PR TITLE
feat: skip global registration for internal generated code

### DIFF
--- a/features/protoc/main.go
+++ b/features/protoc/main.go
@@ -7,25 +7,30 @@ package protoc
 
 import (
 	"fmt"
-	"github.com/cosmos/cosmos-proto/features/protoc/genid"
-	"github.com/cosmos/cosmos-proto/generator"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"google.golang.org/protobuf/encoding/protowire"
-	"google.golang.org/protobuf/proto"
 	"math"
 	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/exp/slices"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/cosmos/cosmos-proto/features/protoc/genid"
+	"github.com/cosmos/cosmos-proto/generator"
+
 	pref "google.golang.org/protobuf/reflect/protoreflect"
 
-	"github.com/cosmos/cosmos-proto/features/protoc/version"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"
+
+	"github.com/cosmos/cosmos-proto/features/protoc/version"
 
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
@@ -60,6 +65,7 @@ var (
 	protojsonPackage     goImportPath = protogen.GoImportPath("google.golang.org/protobuf/encoding/protojson")
 	protoreflectPackage  goImportPath = protogen.GoImportPath("google.golang.org/protobuf/reflect/protoreflect")
 	protoregistryPackage goImportPath = protogen.GoImportPath("google.golang.org/protobuf/reflect/protoregistry")
+	runtimePackage                    = protogen.GoImportPath("github.com/cosmos/cosmos-proto/runtime")
 )
 
 // GenerateFile generates the contents of a .pb.go file.
@@ -360,6 +366,12 @@ func genReflectFileDescriptor(gen *protogen.Plugin, g *generator.GeneratedFile, 
 		}
 	}
 
+	isInternal := false
+	pathParts := strings.Split(f.GoImportPath.String(), "/")
+	if slices.Contains(pathParts, "internal") {
+		isInternal = true
+	}
+
 	g.P("type x struct{}")
 	g.P("out := ", protoimplPackage.Ident("TypeBuilder"), "{")
 	g.P("File: ", protoimplPackage.Ident("DescBuilder"), "{")
@@ -369,6 +381,9 @@ func genReflectFileDescriptor(gen *protogen.Plugin, g *generator.GeneratedFile, 
 	g.P("NumMessages: ", len(f.allMessages), ",")
 	g.P("NumExtensions: ", len(f.allExtensions), ",")
 	g.P("NumServices: ", len(f.Services), ",")
+	if isInternal {
+		g.P("FileRegistry: ", runtimePackage.Ident("NullRegistry"), "{},")
+	}
 	g.P("},")
 	g.P("GoTypes: ", goTypesVarName(f), ",")
 	g.P("DependencyIndexes: ", depIdxsVarName(f), ",")
@@ -380,6 +395,9 @@ func genReflectFileDescriptor(gen *protogen.Plugin, g *generator.GeneratedFile, 
 	}
 	if len(f.allExtensions) > 0 {
 		g.P("ExtensionInfos: ", extensionTypesVarName(f), ",")
+	}
+	if isInternal {
+		g.P("TypeRegistry: ", runtimePackage.Ident("NullRegistry"), "{},")
 	}
 	g.P("}.Build()")
 	g.P(f.GoDescriptorIdent, " = out.File")

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20220907003533-145caa8ea1d0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+golang.org/x/exp v0.0.0-20220907003533-145caa8ea1d0 h1:17k44ji3KFYG94XS5QEFC8pyuOlMh3IoR+vkmTZmJJs=
+golang.org/x/exp v0.0.0-20220907003533-145caa8ea1d0/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=

--- a/internal/testprotos/test3/test.pulsar.go
+++ b/internal/testprotos/test3/test.pulsar.go
@@ -12605,11 +12605,13 @@ func file_internal_testprotos_test3_test_proto_init() {
 			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,
+			FileRegistry:  runtime.NullRegistry{},
 		},
 		GoTypes:           file_internal_testprotos_test3_test_proto_goTypes,
 		DependencyIndexes: file_internal_testprotos_test3_test_proto_depIdxs,
 		EnumInfos:         file_internal_testprotos_test3_test_proto_enumTypes,
 		MessageInfos:      file_internal_testprotos_test3_test_proto_msgTypes,
+		TypeRegistry:      runtime.NullRegistry{},
 	}.Build()
 	File_internal_testprotos_test3_test_proto = out.File
 	file_internal_testprotos_test3_test_proto_rawDesc = nil

--- a/internal/testprotos/test3/test_import.pulsar.go
+++ b/internal/testprotos/test3/test_import.pulsar.go
@@ -525,11 +525,13 @@ func file_internal_testprotos_test3_test_import_proto_init() {
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
+			FileRegistry:  runtime.NullRegistry{},
 		},
 		GoTypes:           file_internal_testprotos_test3_test_import_proto_goTypes,
 		DependencyIndexes: file_internal_testprotos_test3_test_import_proto_depIdxs,
 		EnumInfos:         file_internal_testprotos_test3_test_import_proto_enumTypes,
 		MessageInfos:      file_internal_testprotos_test3_test_import_proto_msgTypes,
+		TypeRegistry:      runtime.NullRegistry{},
 	}.Build()
 	File_internal_testprotos_test3_test_import_proto = out.File
 	file_internal_testprotos_test3_test_import_proto_rawDesc = nil

--- a/internal/testprotos/test3/test_nesting.pulsar.go
+++ b/internal/testprotos/test3/test_nesting.pulsar.go
@@ -2061,10 +2061,12 @@ func file_internal_testprotos_test3_test_nesting_proto_init() {
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
+			FileRegistry:  runtime.NullRegistry{},
 		},
 		GoTypes:           file_internal_testprotos_test3_test_nesting_proto_goTypes,
 		DependencyIndexes: file_internal_testprotos_test3_test_nesting_proto_depIdxs,
 		MessageInfos:      file_internal_testprotos_test3_test_nesting_proto_msgTypes,
+		TypeRegistry:      runtime.NullRegistry{},
 	}.Build()
 	File_internal_testprotos_test3_test_nesting_proto = out.File
 	file_internal_testprotos_test3_test_nesting_proto_rawDesc = nil

--- a/runtime/nullregistry.go
+++ b/runtime/nullregistry.go
@@ -1,0 +1,23 @@
+package runtime
+
+import (
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// NullRegistry is an implementation of the interfaces used to register generated
+// types and file descriptors that does nothing. This is used to generated
+// protobuf files in internal packages that are not registered with the global registry.
+type NullRegistry struct{}
+
+func (NullRegistry) RegisterMessage(protoreflect.MessageType) error     { return nil }
+func (NullRegistry) RegisterEnum(protoreflect.EnumType) error           { return nil }
+func (NullRegistry) RegisterExtension(protoreflect.ExtensionType) error { return nil }
+func (NullRegistry) RegisterFile(protoreflect.FileDescriptor) error     { return nil }
+
+func (NullRegistry) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+	return protoregistry.GlobalFiles.FindFileByPath(path)
+}
+func (NullRegistry) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+	return protoregistry.GlobalFiles.FindDescriptorByName(name)
+}


### PR DESCRIPTION
This feature will enable modules to generate their proto files internally while also allowing clients to use public generated api types for the same proto definitions. This is important because it allows module developers to:
* precisely control the version of generated code used in the state machine
* define interface methods on generated code without having to worry about interface breakage for clients

ref https://github.com/cosmos/cosmos-sdk/pull/11802