### PR TITLE
build: push automatically to buf

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -1,0 +1,20 @@
+name: Buf-Push
+# Protobuf runs buf (https://buf.build/) push updated proto files to https://buf.build/cosmos/cosmos-proto
+# This workflow is only run when a .proto file has been changed
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "proto/**"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1.4.0
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          input: "proto"
+          buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Changes in `cosmos.proto` aren't automatically pushed to buf: https://buf.build/cosmos/cosmos-proto/commits/main
I have already added the buf token.

To be merged AFTER https://github.com/cosmos/cosmos-proto/pull/93