### PR TITLE
fix: Add `/` prefix to Any TypeURL

### DIFF
--- a/any/any.go
+++ b/any/any.go
@@ -57,7 +57,7 @@ func MarshalFrom(dst *anypb.Any, src proto.Message, opts proto.MarshalOptions) e
 	if err != nil {
 		return err
 	}
-	dst.TypeUrl = string(src.ProtoReflect().Descriptor().FullName())
+	dst.TypeUrl = "/" + string(src.ProtoReflect().Descriptor().FullName())
 	dst.Value = b
 	return nil
 }

--- a/any/any_test.go
+++ b/any/any_test.go
@@ -19,11 +19,11 @@ func TestAny(t *testing.T) {
 	dst1 := &anypb.Any{}
 	err := any.MarshalFrom(dst1, value, proto.MarshalOptions{})
 	require.NoError(t, err)
-	require.Equal(t, "A", dst1.TypeUrl) // Make sure there's no "type.googleapis.com/" prefix.
+	require.Equal(t, "/A", dst1.TypeUrl) // Make sure there's no "type.googleapis.com/" prefix.
 
 	dst2, err := any.New(value)
 	require.NoError(t, err)
-	require.Equal(t, "A", dst2.TypeUrl) // Make sure there's no "type.googleapis.com/" prefix.
+	require.Equal(t, "/A", dst2.TypeUrl) // Make sure there's no "type.googleapis.com/" prefix.
 
 	// Round trip.
 	newValue, err := anypb.UnmarshalNew(dst2, proto.UnmarshalOptions{})


### PR DESCRIPTION
I believe I missed the `/` prefix in #92. 

This is basically the same as our old `codec/types.Any`, but for the `google.golang.org/protobuf`'s Any: https://github.com/cosmos/cosmos-sdk/blob/37a9bc3bb67bd82d4493d2d86f8cd31c0e768880/codec/types/any.go#L69