### PR TITLE
chore: alias `anyutil` to `any`

### DIFF
--- a/any/alias.go
+++ b/any/alias.go
@@ -1,0 +1,11 @@
+// package any
+// deprecated: use anyutil package instead
+package any
+
+import "github.com/cosmos/cosmos-proto/anyutil"
+
+var (
+	New         = anyutil.New
+	MarshalFrom = anyutil.MarshalFrom
+	Unpack      = anyutil.Unpack
+)


### PR DESCRIPTION
v1.0.0-beta.3 had a breaking change (https://github.com/cosmos/cosmos-proto/compare/v1.0.0-beta.2..v1.0.0-beta.3), which gives some issue to use latest cosmos-proto with v0.47.

This adds an alias for not blocking bumping cosmos-proto. (cc @robert-zaremba)

After this PR, I'll tag v1.0.0-beta.4